### PR TITLE
SdOption: Derive IP proto version from ip addr

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,9 @@ pub enum Error {
     /// Invalid ip proto value
     #[error("Unknown ip proto value: {0}")]
     InvalidIpProto(u8),
+    /// Mismatch between requested sd option type and ip proto version
+    #[error("Mismatch between sd option type {0} and ip proto version {1}")]
+    SdOptionTypeIpMismatch(u8, u8),
     /// Invalid ip proto value
     #[cfg(feature = "url")]
     #[error("Invalid url: {0}")]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -505,12 +505,12 @@ mod test {
                         },
                     })],
                     options: vec![
-                        SdOption::Ip4Unicast(SdEndpointOption {
+                        SdOption::IpUnicast(SdEndpointOption {
                             ip: IpAddr::V4(Ipv4Addr::from_str("127.0.0.1").unwrap()),
                             port: 30000,
                             proto: IpProto::UDP,
                         }),
-                        SdOption::Ip6Unicast(SdEndpointOption {
+                        SdOption::IpUnicast(SdEndpointOption {
                             ip: IpAddr::V6(
                                 Ipv6Addr::from_str("FF0E:0000:0000:0000:0000:FFFF:EFC0:FFFB")
                                     .unwrap()
@@ -606,7 +606,7 @@ mod test {
                             },
                         })
                     ],
-                    options: vec![SdOption::Ip4Unicast(SdEndpointOption {
+                    options: vec![SdOption::IpUnicast(SdEndpointOption {
                         ip: IpAddr::V4(Ipv4Addr::from_str("127.0.0.1").unwrap()),
                         port: 30000,
                         proto: IpProto::UDP,

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -178,10 +178,8 @@ impl SdOption {
         let option_len = self.len();
 
         match self {
-            SdOption::Ip4Unicast(item) => item.to_writer(option_type, option_len, &mut writer),
-            SdOption::Ip4Multicast(item) => item.to_writer(option_type, option_len, &mut writer),
-            SdOption::Ip6Unicast(item) => item.to_writer(option_type, option_len, &mut writer),
-            SdOption::Ip6Multicast(item) => item.to_writer(option_type, option_len, &mut writer),
+            SdOption::IpUnicast(item) => item.to_writer(option_type, option_len, &mut writer),
+            SdOption::IpMulticast(item) => item.to_writer(option_type, option_len, &mut writer),
         }
     }
 }
@@ -488,12 +486,12 @@ mod tests {
                         },
                     })],
                     options: vec![
-                        SdOption::Ip4Unicast(SdEndpointOption {
+                        SdOption::IpUnicast(SdEndpointOption {
                             ip: IpAddr::V4(Ipv4Addr::from_str("127.0.0.1").unwrap()),
                             port: 30000,
                             proto: IpProto::UDP,
                         }),
-                        SdOption::Ip6Unicast(SdEndpointOption {
+                        SdOption::IpUnicast(SdEndpointOption {
                             ip: IpAddr::V6(
                                 Ipv6Addr::from_str("FF0E:0000:0000:0000:0000:FFFF:EFC0:FFFB")
                                     .unwrap()
@@ -587,7 +585,7 @@ mod tests {
                             },
                         })
                     ],
-                    options: vec![SdOption::Ip4Unicast(SdEndpointOption {
+                    options: vec![SdOption::IpUnicast(SdEndpointOption {
                         ip: IpAddr::V4(Ipv4Addr::from_str("127.0.0.1").unwrap()),
                         port: 30000,
                         proto: IpProto::UDP,


### PR DESCRIPTION
Refactor the `SdOption` to derive the IP protocol version from the IP address that it wraps. This prevents invalid `SdOption`s with IP protocol versions not matching the wrapped IP address.